### PR TITLE
Make cursor change to Pointer over posts

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -15,6 +15,14 @@ body {
     padding-bottom: 100px;
 }
 
+tbody tr {
+    cursor: auto;
+}
+
+tbody tr:hover {
+    cursor: pointer;
+}
+
 tr:nth-child(even) {
     background-color: #f2f2f2;
 }


### PR DESCRIPTION
This helps indicate that the user is hovering over something that is clickable. Only issue is that comments will also indicate that they are clickable when they are not.